### PR TITLE
add ASAN python tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
     - name: run python tests
       shell: bash
       working-directory: ${{runner.workspace}}/py4dgeo
+      # see https://github.com/google/sanitizers/issues/934#issuecomment-649516500
       run: |
         mv ../build/_py4dgeo.*.so src/py4dgeo/.
-        PYTHONPATH=src LD_PRELOAD=$(gcc -print-file-name=libasan.so) PYTHONMALLOC=malloc pytest -s
+        PYTHONPATH=src LD_PRELOAD="$(gcc -print-file-name=libasan.so) /usr/lib/x86_64-linux-gnu/libstdc++.so.6" PYTHONMALLOC=malloc pytest -s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
 
   address-sanitizer:
     name: Address sanitizer run
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -133,7 +133,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.9
 
     - name: Install Python development requirements
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
   address-sanitizer:
     name: Address sanitizer run
     runs-on: ubuntu-20.04
+    env:
+      ASAN_OPTIONS: "detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
 
     steps:
     - uses: actions/checkout@v2
@@ -146,7 +148,7 @@ jobs:
     - name: configure cmake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fsanitize=address" -DBUILD_DOCS=OFF
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer" -DBUILD_DOCS=OFF
 
     - name: build
       shell: bash
@@ -156,7 +158,7 @@ jobs:
     - name: run c++ tests
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: ctest
+      run: ctest --rerun-failed --output-on-failure
 
     - name: run python tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,13 +122,22 @@ jobs:
         ./codecov -f coverage2.xml -F cxx
 
   address-sanitizer:
-    name: Address sanitizer run (C++ only)
+    name: Address sanitizer run
     runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install Python development requirements
+      run: |
+        python -m pip install -r requirements-dev.txt
 
     - name: make build directory
       run: cmake -E make_directory ${{runner.workspace}}/build
@@ -143,7 +152,14 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: cmake --build .
 
-    - name: run tests
+    - name: run c++ tests
       shell: bash
       working-directory: ${{runner.workspace}}/build
       run: ctest
+
+    - name: run python tests
+      shell: bash
+      working-directory: ${{runner.workspace}}/py4dgeo
+      run: |
+        mv ../build/_py4dgeo.*.so src/py4dgeo/.
+        PYTHONPATH=src LD_PRELOAD=$(gcc -print-file-name=libasan.so) PYTHONMALLOC=malloc pytest -s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
 
     - name: Install Python development requirements
       run: |
+        python -m pip install numpy xdg
         python -m pip install -r requirements-dev.txt
 
     - name: make build directory
@@ -160,7 +161,10 @@ jobs:
     - name: run python tests
       shell: bash
       working-directory: ${{runner.workspace}}/py4dgeo
-      # see https://github.com/google/sanitizers/issues/934#issuecomment-649516500
+      # for LD_PRELOAD see https://github.com/google/sanitizers/issues/934#issuecomment-649516500
       run: |
         mv ../build/_py4dgeo.*.so src/py4dgeo/.
-        PYTHONPATH=src LD_PRELOAD="$(gcc -print-file-name=libasan.so) /usr/lib/x86_64-linux-gnu/libstdc++.so.6" PYTHONMALLOC=malloc pytest -s
+        echo "leak:/usr/bin/bash" > supp.txt
+        echo "leak:_PyObject_New" >> supp.txt
+        echo "leak:_PyObject_GC" >> supp.txt
+        LSAN_OPTIONS=suppressions="$(pwd)/supp.txt" PYTHONPATH=src LD_PRELOAD="$(gcc -print-file-name=libasan.so) /usr/lib/x86_64-linux-gnu/libstdc++.so.6" PYTHONMALLOC=malloc pytest -s


### PR DESCRIPTION
- use python 3.9 for ASAN
- add suppressions file to suppress Python leaks
- add libstdc++ to LD_PRELOAD as it is needed to properly handle exceptions
- add fsanitize to LD_FLAGS
- enable optional ASAN checks
- verbose ctest output on failed test