### PR TITLE
Remove KDTree precomputation

### DIFF
--- a/benchmarks/cylindersearch_b.cpp
+++ b/benchmarks/cylindersearch_b.cpp
@@ -13,7 +13,6 @@ cylindersearch_benchmark(benchmark::State& state)
   auto [cloud, corepoints] = ahk_benchcloud();
   Epoch epoch(*cloud);
   epoch.kdtree.build_tree(10);
-  epoch.kdtree.precompute(*corepoints, 2.0, MemoryPolicy::MINIMAL);
 
   EigenNormalSet directions(1, 3);
   directions << 0, 0, 1;

--- a/benchmarks/distances_b.cpp
+++ b/benchmarks/distances_b.cpp
@@ -13,8 +13,6 @@ distances_benchmark(benchmark::State& state)
   auto [cloud, corepoints] = ahk_benchcloud();
   Epoch epoch(*cloud);
   epoch.kdtree.build_tree(10);
-  epoch.kdtree.precompute(*corepoints, 2.0, MemoryPolicy::COREPOINTS);
-
   std::vector<double> scales{ 1.0 };
   EigenNormalSet directions(corepoints->rows(), 3);
   EigenNormalSet orientation(1, 3);

--- a/benchmarks/scaling.cpp
+++ b/benchmarks/scaling.cpp
@@ -22,8 +22,6 @@ scalability_benchmark(benchmark::State& state)
     // Set the number of threads according to benchmark state
     omp_set_num_threads(state.range(0));
 
-    epoch.kdtree.precompute(*corepoints, 2.0, MemoryPolicy::COREPOINTS);
-
     std::vector<double> scales{ 1.0 };
     EigenNormalSet directions(corepoints->rows(), 3);
     EigenNormalSet orientation(1, 3);

--- a/include/py4dgeo/kdtree.hpp
+++ b/include/py4dgeo/kdtree.hpp
@@ -110,21 +110,6 @@ public:
    */
   void build_tree(int leaf);
 
-  /** @brief Perform precomputation of radius search results
-   *
-   * Calling this method allows to precompute radius searches for a fixed set
-   * of query points given a maximum radius. In the follow up, the results can
-   * be accessed using the @ref KDTree::precomputed_radius_search method.
-   *
-   * @param querypoints The fixed set of query points we want to perform radius
-   * searches for.
-   * @param maxradius The maximum search radius this precomputation should cover
-   * @param policy The current policy level
-   */
-  void precompute(EigenPointCloudRef querypoints,
-                  double maxradius,
-                  MemoryPolicy policy);
-
   /** @brief Peform radius search around given query point
    *
    * This method determines all the points from the point cloud within the given
@@ -162,36 +147,10 @@ public:
     double radius,
     RadiusSearchDistanceResult& result) const;
 
-  /** @brief Peform radius search around a query point from the precomputation
-   * set
-   *
-   * This method determines all the points from the point cloud within the given
-   * radius of the query point. It determines their indices and the result is
-   * sorted by ascending distance from the query point.
-   *
-   * This method requires a previous call to @ref KDTree::precompute.
-   *
-   * @param[in] index The index of the query point in the precomputation set
-   * @param[in] radius The radius to search within. If this radius is larger
-   * than the maximum radius given to @ref KDTree::precompute, the results will
-   * not be correct.
-   * @param[out] result A data structure to hold the result. It will be cleared
-   * during application.
-   *
-   * @return The amount of points in the return set
-   */
-  std::size_t precomputed_radius_search(const IndexType,
-                                        double,
-                                        RadiusSearchResult&) const;
-
 private:
   Adaptor adaptor;
   std::shared_ptr<KDTreeImpl> search;
   int leaf_parameter = 0;
-  std::vector<std::vector<IndexType>> precomputed_indices;
-  std::vector<std::vector<double>> precomputed_distances;
-  EigenPointCloud precomputed_querypoints;
-  MemoryPolicy precomputed_policy;
 };
 
 } // namespace py4dgeo

--- a/jupyter/customization.ipynb
+++ b/jupyter/customization.ipynb
@@ -231,37 +231,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19071664-9926-406d-8f3b-642f234e8c36",
-   "metadata": {},
-   "source": [
-    "## Running setup code"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "434d6d21-85fe-4738-aee9-aa3e272b95dc",
-   "metadata": {},
-   "source": [
-    "It is possible to inject some setup code into the algorithm workflow. You can e.g. use that to trigger some precomputations:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aba31b98-e7b0-40f1-a040-f197c77bf659",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class SetupAlgorithm(RenamedAlgorithm):\n",
-    "    def setup(self):\n",
-    "        print(\"This algorithm performs some additional setup work\")\n",
-    "\n",
-    "        # Also perform potential setup work by base classes\n",
-    "        super().setup()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "bb0af919-9a7d-4d1b-8937-9199e9f233a5",
    "metadata": {},
    "source": [

--- a/lib/directions.cpp
+++ b/lib/directions.cpp
@@ -22,8 +22,6 @@ compute_multiscale_directions(const Epoch& epoch,
                               EigenNormalSetConstRef orientation,
                               EigenNormalSetRef result)
 {
-  // TODO: Make sure that precomputation has been triggered.
-
 #ifdef PY4DGEO_WITH_OPENMP
 #pragma omp parallel for schedule(dynamic, 1)
 #endif
@@ -32,7 +30,8 @@ compute_multiscale_directions(const Epoch& epoch,
     for (auto scale : scales) {
       // Find the working set on this scale
       KDTree::RadiusSearchResult points;
-      epoch.kdtree.precomputed_radius_search(i, scale, points);
+      auto qp = corepoints.row(i).eval();
+      epoch.kdtree.radius_search(&(qp(0, 0)), scale, points);
       auto subset = epoch.cloud(points, Eigen::all).cast<double>();
 
       // Calculate covariance matrix

--- a/lib/distances.cpp
+++ b/lib/distances.cpp
@@ -51,14 +51,14 @@ compute_distances(EigenPointCloudConstRef corepoints,
 EigenPointCloud
 radius_workingset_finder(const Epoch& epoch,
                          double radius,
-                         EigenPointCloudConstRef,
+                         EigenPointCloudConstRef corepoint,
                          EigenNormalSetConstRef,
                          double,
                          IndexType core_idx)
 {
   // Find the working set in the other epoch
   KDTree::RadiusSearchResult points;
-  epoch.kdtree.precomputed_radius_search(core_idx, radius, points);
+  epoch.kdtree.radius_search(corepoint.data(), radius, points);
   return epoch.cloud(points, Eigen::all);
 }
 

--- a/lib/kdtree.cpp
+++ b/lib/kdtree.cpp
@@ -26,38 +26,6 @@ KDTree::build_tree(int leaf)
   leaf_parameter = leaf;
 }
 
-void
-KDTree::precompute(EigenPointCloudRef querypoints,
-                   double maxradius,
-                   MemoryPolicy policy)
-{
-  precomputed_querypoints = querypoints;
-  precomputed_policy = policy;
-  if (policy < MemoryPolicy::COREPOINTS)
-    return;
-
-  // Resize the output data structures
-  precomputed_indices.resize(querypoints.rows());
-  precomputed_distances.resize(querypoints.rows());
-
-  // Loop over query points and evaluate with maxradius
-#ifdef PY4DGEO_WITH_OPENMP
-#pragma omp parallel for schedule(dynamic, 1)
-#endif
-  for (IndexType i = 0; i < querypoints.rows(); ++i) {
-    RadiusSearchDistanceResult result;
-    radius_search_with_distances(&querypoints(i, 0), maxradius, result);
-
-    precomputed_indices[i].resize(result.size());
-    precomputed_distances[i].resize(result.size());
-
-    for (std::size_t j = 0; j < result.size(); ++j) {
-      precomputed_indices[i][j] = result[j].first;
-      precomputed_distances[i][j] = result[j].second;
-    }
-  }
-}
-
 std::size_t
 KDTree::radius_search(const float* query,
                       double radius,
@@ -76,28 +44,6 @@ KDTree::radius_search_with_distances(const float* query,
 {
   nanoflann::SearchParams params;
   return search->radiusSearch(query, radius * radius, result, params);
-}
-
-std::size_t
-KDTree::precomputed_radius_search(const IndexType idx,
-                                  double radius,
-                                  RadiusSearchResult& result) const
-{
-  // Check whether precomputation was no-op
-  if (precomputed_policy < MemoryPolicy::COREPOINTS)
-    return radius_search(&precomputed_querypoints(idx, 0), radius, result);
-
-  // Access our precomputation
-  result.clear();
-  auto it = std::find_if(precomputed_distances[idx].begin(),
-                         precomputed_distances[idx].end(),
-                         [radius](auto d) { return d > radius * radius; });
-
-  std::copy(precomputed_indices[idx].begin(),
-            precomputed_indices[idx].begin() +
-              (it - precomputed_distances[idx].begin()),
-            std::back_inserter(result));
-  return result.size();
 }
 
 } // namespace py4dgeo

--- a/src/py4dgeo/fallback.py
+++ b/src/py4dgeo/fallback.py
@@ -15,7 +15,7 @@ def radius_workingset_finder(
     max_cylinder_length: float,
     core_idx: int,
 ) -> np.ndarray:
-    indices = epoch.kdtree.precomputed_radius_search(core_idx, radius)
+    indices = epoch.kdtree.radius_search(corepoint, radius)
     return epoch.cloud[indices, :]
 
 

--- a/src/py4dgeo/m3c2.py
+++ b/src/py4dgeo/m3c2.py
@@ -43,15 +43,9 @@ class M3C2LikeAlgorithm(abc.ABC):
         # Check the given number of epochs
         self.check_number_of_epochs()
 
-        # Run setup code defined by the algorithm
-        self.setup()
-
     @property
     def name(self):
         raise NotImplementedError
-
-    def setup(self):
-        pass
 
     def directions(self):
         """The normal direction(s) to use for this algorithm."""
@@ -164,16 +158,3 @@ class M3C2(M3C2LikeAlgorithm):
     @property
     def name(self):
         return "M3C2"
-
-    def setup(self):
-        # Cache KDTree evaluations
-        radius_candidates = []
-        if self.scales is not None:
-            radius_candidates.extend(list(self.scales))
-        if self.radii is not None:
-            radius_candidates.extend(list(self.radii))
-        radius_candidates.append(self.max_cylinder_length)
-        maxradius = max(radius_candidates)
-
-        for epoch in self.epochs:
-            epoch.kdtree.precompute(self.corepoints, maxradius, get_memory_policy())

--- a/src/py4dgeo/py4dgeo_python.cpp
+++ b/src/py4dgeo/py4dgeo_python.cpp
@@ -88,11 +88,6 @@ PYBIND11_MODULE(_py4dgeo, m)
   kdtree.def(
     "build_tree", &KDTree::build_tree, "Trigger building the search tree");
 
-  // Expose the precomputation interface
-  kdtree.def("precompute",
-             &KDTree::precompute,
-             "Precompute radius searches for a number of query points");
-
   // Add all the radius search methods
   kdtree.def(
     "radius_search",
@@ -106,13 +101,6 @@ PYBIND11_MODULE(_py4dgeo, m)
       return as_pyarray(std::move(result));
     },
     "Search point in given radius!");
-
-  kdtree.def("precomputed_radius_search",
-             [](const KDTree& self, IndexType idx, double radius) {
-               KDTree::RadiusSearchResult result;
-               self.precomputed_radius_search(idx, radius, result);
-               return as_pyarray(std::move(result));
-             });
 
   // Pickling support for the KDTree data structure
   kdtree.def("__getstate__", [](const KDTree&) {

--- a/tests/c++/directions_t.cpp
+++ b/tests/c++/directions_t.cpp
@@ -15,7 +15,6 @@ TEST_CASE("M3C2 Multiscale direction calculation", "[compute]")
   auto [cloud, corepoints] = testcloud();
   Epoch epoch(*cloud);
   epoch.kdtree.build_tree(10);
-  epoch.kdtree.precompute(epoch.cloud, 10.0, MemoryPolicy::COREPOINTS);
 
   std::vector<double> scales{ 1.0, 2.0, 3.0 };
   EigenNormalSet result(epoch.cloud.rows(), 3);

--- a/tests/c++/distances_t.cpp
+++ b/tests/c++/distances_t.cpp
@@ -14,7 +14,6 @@ TEST_CASE("M3C2 distance calculation", "[compute]")
   auto [cloud, corepoints] = testcloud();
   Epoch epoch(*cloud);
   epoch.kdtree.build_tree(10);
-  epoch.kdtree.precompute(epoch.cloud, 10.0, MemoryPolicy::COREPOINTS);
 
   std::vector<double> scales{ 3.0 };
   EigenNormalSet directions(epoch.cloud.rows(), 3);
@@ -59,7 +58,6 @@ TEST_CASE("Single-direction M3C2 distance calculation", "[compute]")
   auto [cloud, corepoints] = testcloud();
   Epoch epoch(*cloud);
   epoch.kdtree.build_tree(10);
-  epoch.kdtree.precompute(epoch.cloud, 10.0, MemoryPolicy::COREPOINTS);
 
   // Single distance vector
   EigenNormalSet directions(1, 3);
@@ -95,7 +93,6 @@ TEST_CASE("Cylinder Search Correctness", "[compute]")
   auto [cloud, corepoints] = testcloud();
   Epoch epoch(*cloud);
   epoch.kdtree.build_tree(10);
-  epoch.kdtree.precompute(epoch.cloud, 10.0, MemoryPolicy::MINIMAL);
 
   EigenPointCloud corepoint(1, 3);
   corepoint << 10, 10, 0;

--- a/tests/c++/kdtree_t.cpp
+++ b/tests/c++/kdtree_t.cpp
@@ -44,6 +44,8 @@ TEST_CASE("KDTree is correctly build", "[kdtree]")
     auto num = tree.radius_search_with_distances(o.data(), 100.0, result);
     REQUIRE(num == epoch.cloud.rows());
     REQUIRE(result.size() == epoch.cloud.rows());
-    REQUIRE(std::is_sorted(result.begin(), result.end(), [](auto a, auto b){ return a.second < b.second; }));
+    REQUIRE(std::is_sorted(result.begin(), result.end(), [](auto a, auto b) {
+      return a.second < b.second;
+    }));
   }
 }

--- a/tests/c++/kdtree_t.cpp
+++ b/tests/c++/kdtree_t.cpp
@@ -34,39 +34,16 @@ TEST_CASE("KDTree is correctly build", "[kdtree]")
     REQUIRE(result.size() == epoch.cloud.rows());
   }
 
-  SECTION("Precomputation and radius search")
+  SECTION("Perform radius search with distances")
   {
-    EigenPointCloud qp = epoch.cloud(Eigen::seq(0, 20), Eigen::all);
-    tree.precompute(qp, 20.0, MemoryPolicy::COREPOINTS);
+    // Find all nodes with a radius search
+    std::array<float, 3> o{ 0.0, 0.0, 0.0 };
+    KDTree::RadiusSearchDistanceResult result;
 
-    for (std::size_t i = 0; i < 20; ++i) {
-      KDTree::RadiusSearchResult result1, result2;
-      tree.radius_search(&qp(i, 0), 5.0, result1);
-      tree.precomputed_radius_search(i, 5.0, result2);
-      REQUIRE(result1.size() == result2.size());
-      std::sort(result1.begin(), result1.end());
-      std::sort(result2.begin(), result2.end());
-      for (std::size_t j = 0; j < result1.size(); ++j) {
-        REQUIRE(result1[j] == result2[j]);
-      }
-    }
-  }
-
-  SECTION("Pseudo-precomputation with too small memory policy level")
-  {
-    EigenPointCloud qp = epoch.cloud(Eigen::seq(0, 20), Eigen::all);
-    tree.precompute(qp, 20.0, MemoryPolicy::MINIMAL);
-
-    for (std::size_t i = 0; i < 20; ++i) {
-      KDTree::RadiusSearchResult result1, result2;
-      tree.radius_search(&qp(i, 0), 5.0, result1);
-      tree.precomputed_radius_search(i, 5.0, result2);
-      REQUIRE(result1.size() == result2.size());
-      std::sort(result1.begin(), result1.end());
-      std::sort(result2.begin(), result2.end());
-      for (std::size_t j = 0; j < result1.size(); ++j) {
-        REQUIRE(result1[j] == result2[j]);
-      }
-    }
+    // Do radius search with radius wide enough to cover the entire cloud
+    auto num = tree.radius_search_with_distances(o.data(), 100.0, result);
+    REQUIRE(num == epoch.cloud.rows());
+    REQUIRE(result.size() == epoch.cloud.rows());
+    REQUIRE(std::is_sorted(result.begin(), result.end(), [](auto a, auto b){ return a.second < b.second; }));
   }
 }

--- a/tests/python/test_kdtree.py
+++ b/tests/python/test_kdtree.py
@@ -20,15 +20,6 @@ def test_kdtree(epochs):
     result = epoch1.kdtree.radius_search(np.array([0, 0, 0]), 100)
     assert result.shape[0] == data.shape[0]
 
-    # Trigger precomputations
-    epoch1.kdtree.precompute(data[:20, :], 20, get_memory_policy())
-
-    # Compare precomputed and real results
-    for i in range(20):
-        result1 = epoch1.kdtree.radius_search(data[i, :], 5)
-        result2 = epoch1.kdtree.precomputed_radius_search(i, 5)
-        assert result1.shape == result2.shape
-
 
 def test_kdtree_pickle(epochs):
     epoch1, _ = epochs


### PR DESCRIPTION
In the light of the new optimized cylinder search implementation
this precomputation does not have a lot of benefits. At the same
time, it can easily waste large amounts of memory.

This fixes #78.