### PR TITLE
add CI jobs without OpenMP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build-and-test:
-    name: Testing on ${{matrix.os}}
+    name: Testing on ${{matrix.os}} - OpenMP ${{matrix.openmp}}
     runs-on: ${{matrix.os}}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
+        openmp: ['ON', 'OFF']
 
     steps:
     - uses: actions/checkout@v2
@@ -31,7 +32,7 @@ jobs:
         python-version: 3.7
 
     - name: Install OpenMP
-      if: runner.os == 'macOS'
+      if: runner.os == 'macOS' && matrix.openmp == 'ON'
       run: brew install libomp
 
     - name: make build directory
@@ -40,7 +41,7 @@ jobs:
     - name: configure cmake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug -DBUILD_DOCS=OFF -DBUILD_BENCHMARKS=ON
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug -DBUILD_DOCS=OFF -DBUILD_BENCHMARKS=ON -DPY4DGEO_WITH_OPENMP=${{matrix.openmp}}
 
     - name: build
       shell: bash

--- a/benchmarks/scaling.cpp
+++ b/benchmarks/scaling.cpp
@@ -1,3 +1,5 @@
+#include <benchmark/benchmark.h>
+
 #ifdef PY4DGEO_WITH_OPENMP
 
 #include "testsetup.hpp"
@@ -6,8 +8,6 @@
 
 #include <py4dgeo/compute.hpp>
 #include <py4dgeo/epoch.hpp>
-
-#include <benchmark/benchmark.h>
 
 using namespace py4dgeo;
 

--- a/tests/python/test_util.py
+++ b/tests/python/test_util.py
@@ -87,5 +87,9 @@ def test_as_double_precision_strict():
 
 
 def test_set_num_threads():
-    set_num_threads(42)
-    assert get_num_threads() == 42
+    try:
+        set_num_threads(42)
+        assert get_num_threads() == 42
+    except Py4DGeoError as e:
+        assert str(e) == "py4dgeo was built without threading support!"
+        assert get_num_threads() == 1


### PR DESCRIPTION
- add ci jobs with openmp disabled
- ensure scaling benchmark builds without openmp
- add logic to `test_set_num_threads` for when openmp is not enabled
